### PR TITLE
Send the full sketch dict to the sketch page renderer

### DIFF
--- a/ginpar/build.py
+++ b/ginpar/build.py
@@ -299,7 +299,7 @@ def render_sketch_page(build_path, sketch, site, page_template, input_templates)
     sketch_index = open(f"public/{sketch['name']}/index.html", "w+")
     sketch_index.write(
         page_template.render(
-            sketch=unkebab(sketch["name"]),
+            sketch=sketch,
             form="<form>\n" + content + "\n</form>",
             site=site,
         )


### PR DESCRIPTION
## Description

Instead of sending just the name, delegate some logic to the Jinja2
template to render different things in function of `sketch["data"]`.

This, and an appropiate update to @davidomarf/gart, should fix #34.

## Motivation and Context
Give more control to the custom themes, and easing the different treatment to sketch pages depending on the data file.

## How Has This Been Tested?
Locally, using `ginpar-quickstart` repo with latest version of `gart`.
- https://github.com/davidomarf/ginpar-quickstart/commit/f3b108aca3ea6abe893b93d4be92e875f9c7f6aa
- https://github.com/davidomarf/gart/commit/54e73a4e2006f91b39223bb9433ba3108d280ee2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
