### PR TITLE
Release 0.8.1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = '2019, David Omar Flores Chavez'
 author = 'David Omar Flores Chavez'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.8.0'
+release = 'v0.8.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/ginpar/build.py
+++ b/ginpar/build.py
@@ -299,7 +299,7 @@ def render_sketch_page(build_path, sketch, site, page_template, input_templates)
     sketch_index = open(f"public/{sketch['name']}/index.html", "w+")
     sketch_index.write(
         page_template.render(
-            sketch=unkebab(sketch["name"]),
+            sketch=sketch,
             form="<form>\n" + content + "\n</form>",
             site=site,
         )

--- a/ginpar/templates/sketch/data.yaml
+++ b/ginpar/templates/sketch/data.yaml
@@ -1,5 +1,6 @@
 ---
 date: {{ today }}
+global_seed: True
 params:   
   - DIMENSIONS:
       attrs:

--- a/ginpar/templates/sketch/sketch.js
+++ b/ginpar/templates/sketch/sketch.js
@@ -1,17 +1,13 @@
-/* You don't need to initialize your variables in here. However, if you decide
- * to do it, you **must** use `var` instead of `let` or `const`.
- */
-
-var DIMENSIONS = [2048, 2048]
-
 /**
  * Standard function of p5js
  */
 function setup() {
   createCanvas(DIMENSIONS[0], DIMENSIONS[1]).parent("artwork-container");
 
-  // Call draw() only once
-  noLoop();
+  // Use the same seed for every time setup is called.
+  // (These are generated and initialized by Ginpar)
+  randomSeed(RANDOM_SEED);
+  noiseSeed(NOISE_SEED);
 }
 
 /**

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 version = '0.8.0'
 
-requires = ['jinja2 >= 2.7', 'pyyaml', 'click']
+requires = ['jinja2 >= 2.7', 'pyyaml', 'click', 'livereload']
 
 setup_requires = ['wheel']
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-version = '0.8.0'
+version = '0.8.1'
 
 requires = ['jinja2 >= 2.7', 'pyyaml', 'click', 'livereload']
 


### PR DESCRIPTION
## Major Changes
<!--- Describe your changes in detail -->
- Send `sketch` instead of `sketch["name"]` to the sketch page template.
- Use the random and noise seeds of the sketch to name the file of the saved image.

## Minor Changes
- Add `livereload` as required module in `setup.py`.